### PR TITLE
Fix overflow bug

### DIFF
--- a/RateLimiter/SleepingStopwatch.cs
+++ b/RateLimiter/SleepingStopwatch.cs
@@ -26,7 +26,7 @@ namespace Guava.RateLimiter
             if (!Stopwatch.IsHighResolution)
                 return _stopwatch.ElapsedMilliseconds * 1000; //_stopwatch.ElapsedTicks / Stopwatch.Frequency;
 
-            return _stopwatch.ElapsedTicks * 1000000 / Stopwatch.Frequency;
+            return (long)(1000000 * (double)_stopwatch.ElapsedTicks / Stopwatch.Frequency);
         }
 
         public void SleepMicrosUninterruptibly(long micros)


### PR DESCRIPTION
When deployed the code on Linux machine we found it getting stuck every 2:34. Then we found there a negative micros value indicating the overflow arithmetic happened. The code has been working on Windows for a long time because `Stopwatch.Frequency` is 10_000_000 when on Linux the precision is 1_000_000_000 and it got overflow just faster than on Windows.

The proposed fix works fine even on long.MaxValue ticks.